### PR TITLE
Adding Toast component

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,9 +1,11 @@
-defaultSemverRangePrefix: ""
+defaultSemverRangePrefix: ''
 
 nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.3.cjs
+
+npmPublishRegistry: https://registry.yarnpkg.com

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,7 +46,7 @@
     "@types/deepmerge": "2.2.0",
     "@types/glob": "8.0.0",
     "@types/lodash": "4.14.186",
-    "@types/node": "18.7.23",
+    "@types/node": "18.8.0",
     "@types/react": "18.0.21",
     "eslint": "8.24.0",
     "next-compose-plugins": "2.2.1",

--- a/apps/docs/src/components/CodePreview/CodePreview.tsx
+++ b/apps/docs/src/components/CodePreview/CodePreview.tsx
@@ -12,12 +12,14 @@ interface CodePreviewProps {
   /** Name the element to add an accessible editor label */
   name?: string;
   theme: PrismTheme;
+  wrapped?: boolean;
 }
 
 const CodePreview: React.FC<CodePreviewProps> = ({
   code,
   name,
   theme,
+  wrapped = true,
   ...rest
 }) => {
   return (
@@ -30,7 +32,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({
         ...rest,
       }}
       theme={theme}
-      transformCode={(code) => `<>${code}</>`}
+      transformCode={(code) => (wrapped ? `<>${code}</>` : code)}
     >
       <Box
         backgroundColor="neutral1"

--- a/apps/docs/src/pages/[category]/[slug].tsx
+++ b/apps/docs/src/pages/[category]/[slug].tsx
@@ -51,7 +51,6 @@ type StaticProps = {
 };
 
 export const getStaticProps: GetStaticProps<StaticProps> = async (context) => {
-  const category = context.params?.category?.toString() as string;
   const slug = context.params?.slug?.toString() as string;
   const pathname = getAllPaths().find(
     (x) => getComponentName(x) === slug,

--- a/packages/strum-react/package.json
+++ b/packages/strum-react/package.json
@@ -51,6 +51,7 @@
     "@radix-ui/react-label": "1.0.0",
     "@radix-ui/react-radio-group": "1.0.0",
     "@radix-ui/react-select": "1.0.0",
+    "@radix-ui/react-toast": "1.0.0",
     "@radix-ui/react-tooltip": "1.0.0",
     "@vanilla-extract/css": "1.9.1",
     "@vanilla-extract/css-utils": "0.1.2",

--- a/packages/strum-react/src/components/Button/Button.tsx
+++ b/packages/strum-react/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import { Box, BoxProps, Stack } from '../../layouts';
 import { Spinner } from '../Spinner';
 import * as styles from './Button.css';
 
-type BaseProps = {
+type ButtonBaseProps = {
   /** Shape of the button */
   borderRadius?: BoxProps['borderRadius'];
   /** Show a loading spinner as a prefix */
@@ -26,12 +26,12 @@ type WithAnchor = {
 } & Pick<JSX.IntrinsicElements['a'], 'href' | 'rel' | 'target'>;
 
 type WithoutAnchor = {
+  as?: 'button';
   /** Set the disabled state of the button */
   disabled?: boolean;
-  as?: 'button';
 };
 
-type ButtonProps = BaseProps & (WithAnchor | WithoutAnchor);
+export type ButtonProps = ButtonBaseProps & (WithAnchor | WithoutAnchor);
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/packages/strum-react/src/components/Input/Input.docs.mdx
+++ b/packages/strum-react/src/components/Input/Input.docs.mdx
@@ -78,7 +78,7 @@ To control your input with React, simply include a `value` string prop and a `on
 ```tsx live name="controlled input" songTitle="Symphony No. 31" changeSongTitle={(e) => {alert(e.target.value)}}
 <Stack>
   <Input
-    id="input-text"
+    id="controlled-input"
     label="Text input"
     onChange={changeSongTitle}
     type="text"

--- a/packages/strum-react/src/components/Toast/Toast.css.ts
+++ b/packages/strum-react/src/components/Toast/Toast.css.ts
@@ -1,0 +1,161 @@
+import { createVar, keyframes, style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+import { atoms, motionSafe, vars } from '../../css';
+
+export const TOAST_VIEWPORT_PADDING = '2rem';
+const translateDistance = calc.add('100%', TOAST_VIEWPORT_PADDING);
+
+const colorPrimary = createVar();
+const colorSecondary = createVar();
+
+const hide = keyframes({
+  '0%': { opacity: 1 },
+  '100%': { opacity: 0 },
+});
+
+const slideIn = keyframes({
+  from: {
+    transform: `translateX(${translateDistance})`,
+  },
+  to: { transform: 'translateX(0)' },
+});
+
+const swipeOut = keyframes({
+  from: { transform: 'translateX(var(--radix-toast-swipe-end-x))' },
+  to: { transform: `translateX(${translateDistance})` },
+});
+
+export const toastRecipe = recipe({
+  base: [
+    atoms({
+      alignItems: 'center',
+      borderRadius: 'medium',
+      boxShadow: 'medium',
+      borderStyle: 'solid',
+      borderWidth: '1',
+      display: 'flex',
+      padding: '4',
+    }),
+    {
+      columnGap: vars.space[2],
+
+      ...motionSafe({
+        selectors: {
+          '&[data-state="open"]': {
+            animationName: slideIn,
+            animationDuration: vars.transitionDurations[300],
+            animationTimingFunction: vars.transitionEasingFunctions.out,
+          },
+          '&[data-state="closed"]': {
+            animationName: hide,
+            animationDuration: vars.transitionDurations[150],
+            animationTimingFunction: vars.transitionEasingFunctions.in,
+          },
+          '&[data-swipe="move"]': {
+            transform: 'translateX(var(--radix-toast-swipe-move-x))',
+          },
+          '&[data-swipe="cancel"]': {
+            transform: 'translateX(0)',
+            transitionProperty: 'transform',
+            transitionDuration: vars.transitionDurations[300],
+            transitionTimingFunction: vars.transitionEasingFunctions.out,
+          },
+          '&[data-swipe="end"]': {
+            animationName: swipeOut,
+            animationDuration: vars.transitionDurations[150],
+            animationTimingFunction: vars.transitionEasingFunctions.out,
+          },
+        },
+      }),
+    },
+  ],
+  defaultVariants: {
+    color: 'neutral',
+  },
+  variants: {
+    color: {
+      accent: [
+        atoms({
+          backgroundColor: 'accent3',
+          borderColor: 'accent6',
+        }),
+        {
+          vars: {
+            [colorPrimary]: vars.accent.accent12,
+            [colorSecondary]: vars.accent.accent11,
+          },
+        },
+      ],
+      neutral: [
+        atoms({
+          backgroundColor: 'neutral3',
+          borderColor: 'neutral6',
+        }),
+        {
+          vars: {
+            [colorPrimary]: vars.neutral.neutral12,
+            [colorSecondary]: vars.neutral.neutral11,
+          },
+        },
+      ],
+      error: [
+        atoms({
+          backgroundColor: 'error3',
+          borderColor: 'error6',
+        }),
+        {
+          vars: {
+            [colorPrimary]: vars.error.error12,
+            [colorSecondary]: vars.error.error11,
+          },
+        },
+      ],
+      warning: [
+        atoms({
+          backgroundColor: 'warning3',
+          borderColor: 'warning6',
+        }),
+        {
+          vars: {
+            [colorPrimary]: vars.warning.warning12,
+            [colorSecondary]: vars.warning.warning11,
+          },
+        },
+      ],
+      success: [
+        atoms({
+          backgroundColor: 'success3',
+          borderColor: 'success6',
+        }),
+        {
+          vars: {
+            [colorPrimary]: vars.success.success12,
+            [colorSecondary]: vars.success.success11,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const toastTitleStyle = style([
+  atoms({
+    fontSize: 'base',
+    fontWeight: 'medium',
+    marginBottom: '2',
+  }),
+  { color: colorPrimary },
+]);
+
+export const toastDescriptionStyle = style([
+  atoms({
+    fontSize: 'small',
+    margin: '0',
+  }),
+  {
+    color: colorSecondary,
+  },
+]);
+
+export type ToastRecipe = RecipeVariants<typeof toastRecipe>;

--- a/packages/strum-react/src/components/Toast/Toast.docs.mdx
+++ b/packages/strum-react/src/components/Toast/Toast.docs.mdx
@@ -1,6 +1,15 @@
 ---
-title: Input
-subtitle: A small alert message in a fixed position onscreen
-description: A small alert message in a fixed position onscreen
-comingSoon: true
+title: Toast
+subtitle: A small, temporary alert message in a fixed position onscreen
+description: A small, temporary alert message in a fixed position onscreen
 ---
+
+```tsx live name="simple toast"
+<Toast open />
+```
+
+## Props
+
+The `<Toast />` component inherits the props of the [Radix UI Toast.Root Primitive](https://www.radix-ui.com/docs/primitives/components/toast#root), which are not listed below.
+
+<PropsTable sourceLink={sourceLink} types={types} />

--- a/packages/strum-react/src/components/Toast/Toast.docs.mdx
+++ b/packages/strum-react/src/components/Toast/Toast.docs.mdx
@@ -21,18 +21,32 @@ description: A small, temporary alert message in a fixed position onscreen
       <Toast
         action="Action"
         actionDescription="User action is required"
+        actionOnClick={() => alert('Click!')}
+        description="This toast describes an event or expected user action"
         onOpenChange={(openState) => {
           setOpen(openState);
         }}
         open={open}
         title="Toast example"
-      >
-        This toast describes an event or expected user action
-      </Toast>
+      />
     </>
   );
 };
 ```
+
+### Features
+
+- Automatically closes after a defined `duration` (defaults to 5000 ms)
+- Pauses closing on hover, focus, and window blur
+- Supports hotkey to jump to the toast viewport
+- Supports closing via swipe gesture
+- Controlled or uncontrolled
+
+### Accessibility
+
+The `<Toast />` component is meant to display a temporary message where user action is not necessarily required. This is why you must provide an alternative action via the `actionDescription` property to describe an alternate way for screen reader users to take the expected action.
+
+We also provide a `type` property of `foreground`, where toasts are announced immediately via assistive technologies, or `background` where toasts are announced at the next graceful opportunity.
 
 ## Props
 
@@ -40,39 +54,116 @@ The `<Toast />` component inherits the props of the [Radix UI Toast.Root Primiti
 
 <PropsTable sourceLink={sourceLink} types={types} />
 
-## Color
+## Stacking toasts
 
-```tsx live name="toast colors" wrapped={false}
+When multiple `<Toast />` components are present, they will stack automatically.
+
+```tsx live name="stacking toasts" wrapped={false}
 () => {
-  const [open, setOpen] = React.useState(false);
-  const colors = ['neutral', 'accent', 'error', 'warning', 'success'];
+  const [openFirst, setOpenFirst] = React.useState(false);
+  const [openSecond, setOpenSecond] = React.useState(false);
 
   return (
     <>
       <Button
         onClick={() => {
-          setOpen(!open);
+          setOpenFirst(true);
+
+          setTimeout(() => {
+            setOpenSecond(true);
+          }, 1000);
         }}
       >
-        Toggle all toast colors
+        Show toasts
       </Button>
 
-      {colors.map((color) => (
-        <Toast
-          action="Action"
-          actionDescription="No action required"
-          color={color}
-          id={color}
-          onOpenChange={(openState) => {
-            setOpen(openState);
-          }}
-          open={open}
-          title={`${color} toast`}
-        >
-          This is a {color} toast.
-        </Toast>
-      ))}
+      <Toast
+        description="The first toast that is triggered will display."
+        onOpenChange={(openState) => {
+          setOpenFirst(openState);
+        }}
+        open={openFirst}
+        title="First toast"
+      />
+      <Toast
+        description="Then the second toast will appear underneath it."
+        onOpenChange={(openState) => {
+          setOpenSecond(openState);
+        }}
+        open={openSecond}
+        title="Second toast"
+      />
     </>
+  );
+};
+```
+
+## Trigger toasts with `useToast`
+
+The simplest way to trigger a single toast is with our `useToast` hook. The hook can only display one toast at a time, so if you need them to stack you'll have to manage the component state yourself.
+
+The `openToast` function takes an object with the `<Toast />` props as a parameter, except for the the `open` and `onOpenChange` fields.
+
+```tsx live name="useToast hook" wrapped={false}
+() => {
+  const { openToast } = useToast();
+
+  return (
+    <Stack direction="horizontal">
+      <Button
+        onClick={() => {
+          openToast({
+            action: 'Action',
+            actionDescription: "This action doesn't do anything",
+            actionOnClick: () => {
+              alert('Click!');
+            },
+            color: 'accent',
+            description: 'This toast was triggered with the useToast hook!',
+            duration: 10000,
+            title: 'Triggered toast',
+          });
+        }}
+      >
+        Open toast
+      </Button>
+    </Stack>
+  );
+};
+```
+
+## Color
+
+Toasts and their corresponding actions can take on theme colors.
+
+```tsx live name="toast colors" wrapped={false}
+() => {
+  const { openToast } = useToast();
+  const colors = ['Neutral', 'Accent', 'Error', 'Warning', 'Success'];
+
+  return (
+    <Stack direction="horizontal">
+      {colors.map((color) => (
+        <Button
+          color={color.toLowerCase()}
+          key={color}
+          onClick={() => {
+            openToast({
+              action: 'Action',
+              actionDescription: "This action doesn't do anything",
+              actionOnClick: () => {
+                alert('Click!');
+              },
+              color: color.toLowerCase(),
+              description: `Enjoy this ${color.toLowerCase()} toast!`,
+              title: color,
+            });
+          }}
+        >
+          {color}
+        </Button>
+      ))}
+    </Stack>
   );
 };
 ```

--- a/packages/strum-react/src/components/Toast/Toast.docs.mdx
+++ b/packages/strum-react/src/components/Toast/Toast.docs.mdx
@@ -4,8 +4,34 @@ subtitle: A small, temporary alert message in a fixed position onscreen
 description: A small, temporary alert message in a fixed position onscreen
 ---
 
-```tsx live name="simple toast"
-<Toast open />
+```tsx live name="simple toast" wrapped={false}
+() => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setOpen(!open);
+        }}
+      >
+        Toggle toast
+      </Button>
+
+      <Toast
+        action="Action"
+        actionDescription="User action is required"
+        onOpenChange={(openState) => {
+          setOpen(openState);
+        }}
+        open={open}
+        title="Toast example"
+      >
+        This toast describes an event or expected user action
+      </Toast>
+    </>
+  );
+};
 ```
 
 ## Props
@@ -13,3 +39,40 @@ description: A small, temporary alert message in a fixed position onscreen
 The `<Toast />` component inherits the props of the [Radix UI Toast.Root Primitive](https://www.radix-ui.com/docs/primitives/components/toast#root), which are not listed below.
 
 <PropsTable sourceLink={sourceLink} types={types} />
+
+## Color
+
+```tsx live name="toast colors" wrapped={false}
+() => {
+  const [open, setOpen] = React.useState(false);
+  const colors = ['neutral', 'accent', 'error', 'warning', 'success'];
+
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setOpen(!open);
+        }}
+      >
+        Toggle all toast colors
+      </Button>
+
+      {colors.map((color) => (
+        <Toast
+          action="Action"
+          actionDescription="No action required"
+          color={color}
+          id={color}
+          onOpenChange={(openState) => {
+            setOpen(openState);
+          }}
+          open={open}
+          title={`${color} toast`}
+        >
+          This is a {color} toast.
+        </Toast>
+      ))}
+    </>
+  );
+};
+```

--- a/packages/strum-react/src/components/Toast/Toast.tsx
+++ b/packages/strum-react/src/components/Toast/Toast.tsx
@@ -1,0 +1,50 @@
+import * as RadixToast from '@radix-ui/react-toast';
+import * as React from 'react';
+
+type PrimitiveProps = RadixToast.ToastProps;
+
+type ToastProps = {
+  /** The time in milliseconds that should elapse before automatically closing the toast. */
+  duration?: PrimitiveProps['duration'];
+  /** Event handler called when the open state of the dialog changes. */
+  onOpenChange?: PrimitiveProps['onOpenChange'];
+  /** The controlled open state of the dialog. Must be used in conjunction with onOpenChange. */
+  open?: PrimitiveProps['open'];
+  title?: string;
+  /** For toasts that are the result of a user action, choose foreground. Toasts generated from background tasks should use background. */
+  type?: PrimitiveProps['type'];
+} & PrimitiveProps;
+
+export const Toast = React.forwardRef<
+  HTMLLIElement,
+  React.PropsWithChildren<ToastProps>
+>(({ title, ...primitiveProps }, ref) => {
+  const [open, setOpen] = React.useState(false);
+  const eventDateRef = React.useRef(new Date());
+  const timerRef = React.useRef(0);
+
+  React.useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  return (
+    <>
+      <RadixToast.Root open={open} onOpenChange={setOpen} ref={ref}>
+        {title && <RadixToast.ToastTitle>{title}</RadixToast.ToastTitle>}
+        <RadixToast.ToastDescription asChild>
+          {/* <time dateTime={eventDateRef.current.toISOString()}>
+            {prettyDate(eventDateRef.current)}
+          </time> */}
+        </RadixToast.ToastDescription>
+        <RadixToast.ToastAction asChild altText="Goto schedule to undo">
+          {/* <Button variant="green" size="small">
+            Undo
+          </Button> */}
+        </RadixToast.ToastAction>
+      </RadixToast.Root>
+      <RadixToast.ToastViewport />
+    </>
+  );
+});
+
+Toast.displayName = 'Toast';

--- a/packages/strum-react/src/components/Toast/Toast.tsx
+++ b/packages/strum-react/src/components/Toast/Toast.tsx
@@ -1,50 +1,101 @@
 import * as RadixToast from '@radix-ui/react-toast';
 import * as React from 'react';
+import { Box } from '../../layouts';
+import { Button } from '../Button';
+import { ButtonProps } from '../Button/Button';
+import * as styles from './Toast.css';
 
 type PrimitiveProps = RadixToast.ToastProps;
 
-type ToastProps = {
+type ToastBaseProps = {
   /** The time in milliseconds that should elapse before automatically closing the toast. */
   duration?: PrimitiveProps['duration'];
-  /** Event handler called when the open state of the dialog changes. */
+  /** Event handler called when the open state of the toast changes. */
   onOpenChange?: PrimitiveProps['onOpenChange'];
-  /** The controlled open state of the dialog. Must be used in conjunction with onOpenChange. */
+  /** The controlled open state of the toast. Must be used in conjunction with onOpenChange. */
   open?: PrimitiveProps['open'];
-  title?: string;
+  /** An optional title for the toast. */
+  title?: React.ReactNode;
   /** For toasts that are the result of a user action, choose foreground. Toasts generated from background tasks should use background. */
   type?: PrimitiveProps['type'];
-} & PrimitiveProps;
+} & PrimitiveProps &
+  styles.ToastRecipe;
+
+type ToastWithoutAction = {
+  action: never;
+  actionColor: never;
+  actionDescription: never;
+  actionOnClick: never;
+};
+
+type ToastWithAction = {
+  /** Text of the action button. */
+  action: string;
+  /** Describe an alternative way to achieve the action for screen reader users who cannot access the toast easily. */
+  actionDescription: string;
+  /** Callback when user clicks the action button. */
+  actionOnClick?: ButtonProps['onClick'];
+};
+
+export type ToastProps = ToastBaseProps &
+  (ToastWithAction | ToastWithoutAction);
 
 export const Toast = React.forwardRef<
   HTMLLIElement,
   React.PropsWithChildren<ToastProps>
->(({ title, ...primitiveProps }, ref) => {
-  const [open, setOpen] = React.useState(false);
-  const eventDateRef = React.useRef(new Date());
-  const timerRef = React.useRef(0);
+>(
+  (
+    {
+      action,
+      actionDescription,
+      children,
+      color = 'neutral',
+      duration,
+      onOpenChange,
+      open,
+      title,
+      ...primitiveProps
+    },
+    ref,
+  ) => {
+    return (
+      <RadixToast.Root
+        className={styles.toastRecipe({
+          color,
+        })}
+        duration={duration}
+        onOpenChange={onOpenChange}
+        open={open}
+        ref={ref}
+        {...primitiveProps}
+      >
+        <Box flexGrow={1}>
+          {title && (
+            <RadixToast.ToastTitle className={styles.toastTitleStyle}>
+              {title}
+            </RadixToast.ToastTitle>
+          )}
 
-  React.useEffect(() => {
-    return () => clearTimeout(timerRef.current);
-  }, []);
+          <RadixToast.ToastDescription className={styles.toastDescriptionStyle}>
+            {children}
+          </RadixToast.ToastDescription>
+        </Box>
 
-  return (
-    <>
-      <RadixToast.Root open={open} onOpenChange={setOpen} ref={ref}>
-        {title && <RadixToast.ToastTitle>{title}</RadixToast.ToastTitle>}
-        <RadixToast.ToastDescription asChild>
-          {/* <time dateTime={eventDateRef.current.toISOString()}>
-            {prettyDate(eventDateRef.current)}
-          </time> */}
-        </RadixToast.ToastDescription>
-        <RadixToast.ToastAction asChild altText="Goto schedule to undo">
-          {/* <Button variant="green" size="small">
-            Undo
-          </Button> */}
-        </RadixToast.ToastAction>
+        {action && (
+          <Box>
+            <RadixToast.ToastAction altText={actionDescription} asChild>
+              <Button
+                color={color === 'neutral' ? 'accent' : color}
+                size="small"
+              >
+                {action}
+              </Button>
+            </RadixToast.ToastAction>
+          </Box>
+        )}
       </RadixToast.Root>
-      <RadixToast.ToastViewport />
-    </>
-  );
-});
+    );
+  },
+);
 
 Toast.displayName = 'Toast';

--- a/packages/strum-react/src/components/Toast/Toast.tsx
+++ b/packages/strum-react/src/components/Toast/Toast.tsx
@@ -8,6 +8,8 @@ import * as styles from './Toast.css';
 type PrimitiveProps = RadixToast.ToastProps;
 
 type ToastBaseProps = {
+  /** The toast message. */
+  description: React.ReactNode;
   /** The time in milliseconds that should elapse before automatically closing the toast. */
   duration?: PrimitiveProps['duration'];
   /** Event handler called when the open state of the toast changes. */
@@ -22,10 +24,9 @@ type ToastBaseProps = {
   styles.ToastRecipe;
 
 type ToastWithoutAction = {
-  action: never;
-  actionColor: never;
-  actionDescription: never;
-  actionOnClick: never;
+  action?: never;
+  actionDescription?: never;
+  actionOnClick?: never;
 };
 
 type ToastWithAction = {
@@ -38,22 +39,21 @@ type ToastWithAction = {
 };
 
 export type ToastProps = ToastBaseProps &
-  (ToastWithAction | ToastWithoutAction);
+  (ToastWithoutAction | ToastWithAction);
 
-export const Toast = React.forwardRef<
-  HTMLLIElement,
-  React.PropsWithChildren<ToastProps>
->(
+export const Toast = React.forwardRef<HTMLLIElement, ToastProps>(
   (
     {
       action,
       actionDescription,
-      children,
+      actionOnClick,
       color = 'neutral',
-      duration,
+      description,
+      duration = 5000,
       onOpenChange,
       open,
       title,
+      type = 'foreground',
       ...primitiveProps
     },
     ref,
@@ -67,6 +67,7 @@ export const Toast = React.forwardRef<
         onOpenChange={onOpenChange}
         open={open}
         ref={ref}
+        type={type}
         {...primitiveProps}
       >
         <Box flexGrow={1}>
@@ -77,7 +78,7 @@ export const Toast = React.forwardRef<
           )}
 
           <RadixToast.ToastDescription className={styles.toastDescriptionStyle}>
-            {children}
+            {description}
           </RadixToast.ToastDescription>
         </Box>
 
@@ -86,6 +87,7 @@ export const Toast = React.forwardRef<
             <RadixToast.ToastAction altText={actionDescription} asChild>
               <Button
                 color={color === 'neutral' ? 'accent' : color}
+                onClick={actionOnClick}
                 size="small"
               >
                 {action}

--- a/packages/strum-react/src/components/Toast/index.ts
+++ b/packages/strum-react/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from './Toast';

--- a/packages/strum-react/src/components/Toast/index.ts
+++ b/packages/strum-react/src/components/Toast/index.ts
@@ -1,1 +1,2 @@
 export { Toast } from './Toast';
+export { useToast } from './useToast';

--- a/packages/strum-react/src/components/Toast/useToast.ts
+++ b/packages/strum-react/src/components/Toast/useToast.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { ToastContext } from '../../layouts/StrumProvider/RadixProvider';
+
+export const useToast = () => {
+  const { openToast, toastIsOpen, toastProps } = useContext(ToastContext);
+
+  return { openToast, toastIsOpen, toastProps };
+};

--- a/packages/strum-react/src/components/index.ts
+++ b/packages/strum-react/src/components/index.ts
@@ -13,5 +13,6 @@ export * from './Select';
 export * from './Skeleton';
 export * from './Spinner';
 export * from './Text';
+export * from './Toast';
 export * from './Tooltip';
 export * from './VisuallyHidden';

--- a/packages/strum-react/src/layouts/StrumProvider/RadixProvider.css.ts
+++ b/packages/strum-react/src/layouts/StrumProvider/RadixProvider.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css';
+import { TOAST_VIEWPORT_PADDING } from '../../components/Toast/Toast.css';
+import { atoms } from '../../css';
+
+export const toastViewportStyle = style([
+  atoms({
+    bottom: '0',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4',
+    position: 'fixed',
+    margin: '0',
+    maxWidth: '100vw',
+    right: '0',
+    zIndex: '100',
+  }),
+  {
+    listStyle: 'none',
+    outline: 'none',
+    padding: TOAST_VIEWPORT_PADDING,
+    width: '24rem',
+  },
+]);

--- a/packages/strum-react/src/layouts/StrumProvider/RadixProvider.tsx
+++ b/packages/strum-react/src/layouts/StrumProvider/RadixProvider.tsx
@@ -1,0 +1,16 @@
+import * as RadixToast from '@radix-ui/react-toast';
+import * as RadixTooltip from '@radix-ui/react-tooltip';
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
+import * as styles from './RadixProvider.css';
+
+export const RadixProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <RadixTooltip.Provider>
+      <RadixToast.Provider swipeDirection="right">
+        {children}
+        <RadixToast.Viewport className={styles.toastViewportStyle} />
+      </RadixToast.Provider>
+    </RadixTooltip.Provider>
+  );
+};

--- a/packages/strum-react/src/layouts/StrumProvider/RadixProvider.tsx
+++ b/packages/strum-react/src/layouts/StrumProvider/RadixProvider.tsx
@@ -2,14 +2,79 @@ import * as RadixToast from '@radix-ui/react-toast';
 import * as RadixTooltip from '@radix-ui/react-tooltip';
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
+import { Toast } from '../../components';
+import { ToastProps } from '../../components/Toast/Toast';
 import * as styles from './RadixProvider.css';
 
+const TOAST_DURATION = 5000;
+
+type ToastContextProps = Omit<ToastProps, 'open' | 'onOpenChange'>;
+
+type ToastContextState = {
+  openToast: (toastProps: ToastContextProps) => void;
+  toastIsOpen: boolean;
+  toastProps?: ToastContextProps;
+  setToastIsOpen: (toastIsOpen: boolean) => void;
+  setToastProps: (toastProps: ToastContextProps) => void;
+};
+
+export const ToastContext = React.createContext<ToastContextState>({
+  openToast: () => null,
+  toastIsOpen: false,
+  setToastIsOpen: () => null,
+  setToastProps: () => null,
+});
+
 export const RadixProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [toastIsOpen, setToastIsOpen] = React.useState(false);
+  const [toastProps, setToastProps] = React.useState<ToastContextProps>({
+    description: '',
+    duration: TOAST_DURATION,
+  });
+  const timerRef = React.useRef(0);
+
+  const openToast = (props: ToastContextProps) => {
+    if (toastIsOpen) {
+      // close the current toast
+      setToastIsOpen(false);
+
+      window.clearTimeout(timerRef.current);
+
+      timerRef.current = window.setTimeout(() => {
+        setToastProps(props);
+        setToastIsOpen(true);
+      }, 150);
+    } else {
+      setToastProps(props);
+      setToastIsOpen(true);
+    }
+  };
+
+  React.useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
   return (
     <RadixTooltip.Provider>
       <RadixToast.Provider swipeDirection="right">
-        {children}
-        <RadixToast.Viewport className={styles.toastViewportStyle} />
+        <ToastContext.Provider
+          value={{
+            openToast,
+            toastIsOpen,
+            toastProps,
+            setToastIsOpen,
+            setToastProps,
+          }}
+        >
+          {children}
+
+          <Toast
+            open={toastIsOpen}
+            onOpenChange={setToastIsOpen}
+            {...toastProps}
+          />
+          <RadixToast.Viewport className={styles.toastViewportStyle} />
+        </ToastContext.Provider>
       </RadixToast.Provider>
     </RadixTooltip.Provider>
   );

--- a/packages/strum-react/src/layouts/StrumProvider/StrumProvider.tsx
+++ b/packages/strum-react/src/layouts/StrumProvider/StrumProvider.tsx
@@ -1,5 +1,3 @@
-import * as RadixToast from '@radix-ui/react-toast';
-import * as RadixTooltip from '@radix-ui/react-tooltip';
 import * as React from 'react';
 import { strumTheme } from '../../css';
 import {
@@ -17,6 +15,7 @@ import {
   getTheme,
   setStored,
 } from './helpers';
+import { RadixProvider } from './RadixProvider';
 import type { StrumProviderProps, UseThemeProps } from './types';
 
 const darkThemeClass = strumTheme({ theme: 'dark' });
@@ -194,9 +193,8 @@ const Theme: React.FC<StrumProviderProps> = ({
           nonce,
         }}
       />
-      <RadixToast.Provider swipeDirection="right">
-        <RadixTooltip.Provider>{children}</RadixTooltip.Provider>
-      </RadixToast.Provider>
+
+      <RadixProvider>{children}</RadixProvider>
     </ThemeContext.Provider>
   );
 };

--- a/packages/strum-react/src/layouts/StrumProvider/StrumProvider.tsx
+++ b/packages/strum-react/src/layouts/StrumProvider/StrumProvider.tsx
@@ -1,3 +1,4 @@
+import * as RadixToast from '@radix-ui/react-toast';
 import * as RadixTooltip from '@radix-ui/react-tooltip';
 import * as React from 'react';
 import { strumTheme } from '../../css';
@@ -193,7 +194,9 @@ const Theme: React.FC<StrumProviderProps> = ({
           nonce,
         }}
       />
-      <RadixTooltip.Provider>{children}</RadixTooltip.Provider>
+      <RadixToast.Provider swipeDirection="right">
+        <RadixTooltip.Provider>{children}</RadixTooltip.Provider>
+      </RadixToast.Provider>
     </ThemeContext.Provider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,10 +3519,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.7.23":
-  version: 18.7.23
-  resolution: "@types/node@npm:18.7.23"
-  checksum: 2c8df0830d8345e5cd1ca17feb9cf43fa667aae749888e0a068c5c1b35eaedd2f9b24ed987a0758078395edf7a03681e5e0b7790a518ff7afe1ff6d8459f7b4a
+"@types/node@npm:18.8.0":
+  version: 18.8.0
+  resolution: "@types/node@npm:18.8.0"
+  checksum: 3433cbc22e90fafb047f93b3ef05ba01a07f780a24ff1af393f435f807537b533fe9e8a816586825f4c5fd5336c3e80225571f44ec3b6479c463408c072773e7
   languageName: node
   linkType: hard
 
@@ -5133,7 +5133,7 @@ __metadata:
     "@types/deepmerge": 2.2.0
     "@types/glob": 8.0.0
     "@types/lodash": 4.14.186
-    "@types/node": 18.7.23
+    "@types/node": 18.8.0
     "@types/react": 18.0.21
     "@vanilla-extract/css": 1.9.1
     "@vanilla-extract/css-utils": 0.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2779,6 +2779,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-toast@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-toast@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.0
+    "@radix-ui/react-collection": 1.0.0
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-context": 1.0.0
+    "@radix-ui/react-dismissable-layer": 1.0.0
+    "@radix-ui/react-portal": 1.0.0
+    "@radix-ui/react-presence": 1.0.0
+    "@radix-ui/react-primitive": 1.0.0
+    "@radix-ui/react-use-callback-ref": 1.0.0
+    "@radix-ui/react-use-controllable-state": 1.0.0
+    "@radix-ui/react-use-layout-effect": 1.0.0
+    "@radix-ui/react-visually-hidden": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 3d5ddd13a41d02871ffbf6c49470ae09d6a5bbfa2d6aaec43467026e1bd6b1d214d54ca0c9caa168fabcc823e1417d41ca44b9b6bced467d6b9faed0de87e29c
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-tooltip@npm:1.0.0":
   version: 1.0.0
   resolution: "@radix-ui/react-tooltip@npm:1.0.0"
@@ -3032,6 +3056,7 @@ __metadata:
     "@radix-ui/react-label": 1.0.0
     "@radix-ui/react-radio-group": 1.0.0
     "@radix-ui/react-select": 1.0.0
+    "@radix-ui/react-toast": 1.0.0
     "@radix-ui/react-tooltip": 1.0.0
     "@strum/eslint-config": "*"
     "@strum/tsconfig": "*"


### PR DESCRIPTION
Adds a `<Toast />` component alongside a `useToast` hook for triggering single toasts.

Breaks the Radix providers into their own component.